### PR TITLE
feat: Add Proxmox API Token support

### DIFF
--- a/alpine-3-amd64/proxmox_source.pkr.hcl
+++ b/alpine-3-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "alpine" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/alpine-3-amd64/variables.pkr.hcl
+++ b/alpine-3-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####

--- a/debian-11-amd64/proxmox_source.pkr.hcl
+++ b/debian-11-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "debian" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/debian-11-amd64/variables.pkr.hcl
+++ b/debian-11-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####

--- a/debian-12-amd64/proxmox_source.pkr.hcl
+++ b/debian-12-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "debian" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/debian-12-amd64/variables.pkr.hcl
+++ b/debian-12-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####

--- a/ubuntu-20.04-amd64/proxmox_source.pkr.hcl
+++ b/ubuntu-20.04-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "ubuntu" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/ubuntu-20.04-amd64/variables.pkr.hcl
+++ b/ubuntu-20.04-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####

--- a/ubuntu-22.04-amd64/proxmox_source.pkr.hcl
+++ b/ubuntu-22.04-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "ubuntu" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/ubuntu-22.04-amd64/variables.pkr.hcl
+++ b/ubuntu-22.04-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####

--- a/ubuntu-24.04-amd64/proxmox_source.pkr.hcl
+++ b/ubuntu-24.04-amd64/proxmox_source.pkr.hcl
@@ -3,6 +3,7 @@ source "proxmox" "ubuntu" {
   node                     = var.proxmox_node
   username                 = var.proxmox_username
   password                 = var.proxmox_password
+  token                    = var.proxmox_token
   insecure_skip_tls_verify = var.proxmox_skip_verify_tls
 
   template_name        = var.template_name

--- a/ubuntu-24.04-amd64/variables.pkr.hcl
+++ b/ubuntu-24.04-amd64/variables.pkr.hcl
@@ -15,6 +15,14 @@ variable "proxmox_password" {
   type        = string
   description = "Password for the user."
   sensitive   = true
+  default     = null
+}
+
+variable "proxmox_token" {
+  type        = string
+  description = "The Proxmox API token."
+  sensitive   = true
+  default     = null
 }
 
 ##### Optional Variables #####


### PR DESCRIPTION
Add token support. Both proxmox_password and proxmox_token are optional, though the plugin will complain if neither is specified.

