### PR TITLE
feat: Update to Debian 12.5

### DIFF
--- a/debian-12-amd64/README.md
+++ b/debian-12-amd64/README.md
@@ -3,5 +3,5 @@
 ## Run examples
 
 ```bash
-packer build -var-file=debian-12.4.pkrvars.hcl -var-file=example.pkrvars.hcl .
+packer build -var-file=debian-12.5.pkrvars.hcl -var-file=example.pkrvars.hcl .
 ```

--- a/debian-12-amd64/debian-12.4.pkrvars.hcl
+++ b/debian-12-amd64/debian-12.4.pkrvars.hcl
@@ -1,7 +1,0 @@
-template_name        = "debian-12.4-cloudinit"
-template_description = "Base template for Debian 12.4."
-
-# Uncomment if the ISO already exists in the 'iso_storage_pool' location
-iso_file = "debian-12.4.0-amd64-netinst.iso"
-#iso_url        = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.4.0-amd64-netinst.iso"
-iso_checksum     = "0262488ce2cec6d95a6c9002cfba8b81ac0d1c29fe7993aa5af30f81cecad3eb66558b9d8689a86b57bf12b8cbeab1e11d128a53356b288d48e339bb003dace5"

--- a/debian-12-amd64/debian-12.5.pkrvars.hcl
+++ b/debian-12-amd64/debian-12.5.pkrvars.hcl
@@ -1,0 +1,7 @@
+template_name        = "debian-12.5-cloudinit"
+template_description = "Base template for Debian 12.5."
+
+# Uncomment if the ISO already exists in the 'iso_storage_pool' location
+#iso_file = "debian-12.5.0-amd64-netinst.iso"
+iso_url        = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.5.0-amd64-netinst.iso"
+iso_checksum     = "33c08e56c83d13007e4a5511b9bf2c4926c4aa12fd5dd56d493c0653aecbab380988c5bf1671dbaea75c582827797d98c4a611f7fb2b131fbde2c677d5258ec9"

--- a/debian-12-amd64/variables.pkr.hcl
+++ b/debian-12-amd64/variables.pkr.hcl
@@ -155,7 +155,7 @@ variable "sockets" {
 variable "iso_url" {
   type        = string
   description = "URL to an ISO file to upload to Proxmox, and then boot from."
-  default     = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.4.0-amd64-netinst.iso"
+  default     = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.5.0-amd64-netinst.iso"
 }
 
 variable "iso_storage_pool" {
@@ -173,7 +173,7 @@ variable "iso_file" {
 variable "iso_checksum" {
   type        = string
   description = "Checksum of the ISO file."
-  default     = "0262488ce2cec6d95a6c9002cfba8b81ac0d1c29fe7993aa5af30f81cecad3eb66558b9d8689a86b57bf12b8cbeab1e11d128a53356b288d48e339bb003dace5"
+  default     = "33c08e56c83d13007e4a5511b9bf2c4926c4aa12fd5dd56d493c0653aecbab380988c5bf1671dbaea75c582827797d98c4a611f7fb2b131fbde2c677d5258ec9"
 }
 
 variable "http_server_host" {


### PR DESCRIPTION
Debian 12.4 is no longer available on the CD image server. Use 12.5 instead.